### PR TITLE
Incorrect label MacOS instead of Windows

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ features:
     icon:
       src: /linux.svg
     details: Available
-  - title: MacOS
+  - title: Windows
     icon:
       src: /windows.svg
     details: Soon!


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0af64651-f67c-4e85-b6d9-8f1519e2362d)
